### PR TITLE
Introduce option to treat directories infrangibly

### DIFF
--- a/src/globals.ml
+++ b/src/globals.ml
@@ -258,7 +258,11 @@ let ignorenotPred =
      and then using {\\tt ignorenot} to select particular paths to be 
      synchronized will not work.  Instead, you should use the {\\tt path}
      preference to choose particular paths to synchronize.")
-    
+
+let atomic = Pred.create "atomic" ~advanced:true
+  ("This preference specifies paths for directories whose \
+     contents will be considered as a group rather than individually.")
+
 let shouldIgnore p =
   let p = Path.toString p in
   (Pred.test ignorePred p) && not (Pred.test ignorenotPred p) 

--- a/src/globals.mli
+++ b/src/globals.mli
@@ -80,6 +80,7 @@ val shouldIgnore : 'a Path.path -> bool
 val shouldMerge : 'a Path.path -> bool
 val ignorePred : Pred.t
 val ignorenotPred : Pred.t
+val atomic : Pred.t
 
 (* Be careful calling this to add new patterns to be ignored: Its
    value does NOT persist when a new profile is loaded, so it has to

--- a/src/recon.ml
+++ b/src/recon.ml
@@ -580,39 +580,53 @@ let rec reconcile
       (add_equal counter equals (Absent, Absent), unequals)
   | (Updates (Dir (desc1, children1, propsChanged1, _) as uc1, prevState1),
      Updates (Dir (desc2, children2, propsChanged2, _) as uc2, prevState2)) ->
-       (* See if the directory itself should have a reconItem *)
-       let dirResult =
-         if propsChanged1 = PropsSame && propsChanged2 = PropsSame then
-           (equals, unequals)
-         else if Props.similar desc1 desc2 then
-           let uc1 = Dir (desc1, [], PropsSame, false) in
-           let uc2 = Dir (desc2, [], PropsSame, false) in
-           (add_equal counter equals (uc1, uc2), unequals)
-         else
-           let action =
-             if propsChanged1 = PropsSame then Replica2ToReplica1
-             else if propsChanged2 = PropsSame then Replica1ToReplica2
-             else Conflict "properties changed on both sides" in
-           (equals,
-            Tree.add unequals
-              (Different
-                 {rc1 = update2replicaContent path false ui1 [] uc1 `DIRECTORY;
-                  rc2 = update2replicaContent path false ui2 [] uc2 `DIRECTORY;
+       let is_atomic_case = match path |> Path.finalName with
+        | Some n -> Pred.test Globals.atomic (Name.toString n)
+        | None -> false
+       in
+       if is_atomic_case then
+         let action = Conflict "atomic directory" in
+         (equals,
+          Tree.add unequals
+            (Different
+                 {rc1 = update2replicaContent path true ui1 [] uc1 `DIRECTORY;
+                  rc2 = update2replicaContent path true ui2 [] uc2 `DIRECTORY;
                   direction = action; default_direction = action;
                   errors1 = []; errors2 = []}))
-       in
-       (* Apply reconcile on children. *)
-       Safelist.fold_left
-         (fun (equals, unequals) (name1,ui1,name2,ui2) ->
-           let (eq, uneq) =
-             reconcile
-               allowPartial (Path.child path name1) ui1 [] ui2 [] counter
-               (Tree.enter equals (name1, name2))
-               (Tree.enter unequals (name1, name2))
-           in
-           (Tree.leave eq, Tree.leave uneq))
-         dirResult
-         (combineChildren children1 children2)
+       else
+         (* See if the directory itself should have a reconItem *)
+         let dirResult =
+           if propsChanged1 = PropsSame && propsChanged2 = PropsSame then
+             (equals, unequals)
+           else if Props.similar desc1 desc2 then
+             let uc1 = Dir (desc1, [], PropsSame, false) in
+             let uc2 = Dir (desc2, [], PropsSame, false) in
+             (add_equal counter equals (uc1, uc2), unequals)
+           else
+             let action =
+               if propsChanged1 = PropsSame then Replica2ToReplica1
+               else if propsChanged2 = PropsSame then Replica1ToReplica2
+               else Conflict "properties changed on both sides" in
+             (equals,
+              Tree.add unequals
+                (Different
+                   {rc1 = update2replicaContent path false ui1 [] uc1 `DIRECTORY;
+                    rc2 = update2replicaContent path false ui2 [] uc2 `DIRECTORY;
+                    direction = action; default_direction = action;
+                    errors1 = []; errors2 = []}))
+         in
+         (* Apply reconcile on children. *)
+         Safelist.fold_left
+           (fun (equals, unequals) (name1,ui1,name2,ui2) ->
+              let (eq, uneq) =
+                reconcile
+                  allowPartial (Path.child path name1) ui1 [] ui2 [] counter
+                  (Tree.enter equals (name1, name2))
+                  (Tree.enter unequals (name1, name2))
+              in
+              (Tree.leave eq, Tree.leave uneq))
+           dirResult
+           (combineChildren children1 children2)
   | (Updates (File (desc1,contentsChanged1) as uc1, prev),
      Updates (File (desc2,contentsChanged2) as uc2, _)) ->
        begin match contentsChanged1, contentsChanged2 with


### PR DESCRIPTION
This adds the `-atomic` preference which matches directories which will be treated in an all-or-nothing manner.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tokenrove/unison/2)

<!-- Reviewable:end -->
